### PR TITLE
Reduce noisy LSPosed log spam

### DIFF
--- a/app/src/main/java/dev/sonypods/hook/SonyEngineHost.kt
+++ b/app/src/main/java/dev/sonypods/hook/SonyEngineHost.kt
@@ -270,7 +270,7 @@ object SonyEngineHost {
     private fun handleCommand(intent: Intent) {
         val repo = repository ?: return
         val command = intent.getStringExtra(SonyBridge.EXTRA_COMMAND) ?: return
-        Log.i(TAG, "command=$command")
+        Log.d(TAG, "command=$command")
         when (command) {
             SonyBridge.CMD_SET_NOISE_CONTROL -> {
                 val mode = intent.getStringExtra(SonyBridge.EXTRA_STRING)
@@ -416,7 +416,7 @@ object SonyEngineHost {
                     singleBattery = snapshot.batterySingle != null && snapshot.batteryLeft == null,
                 )
             }
-            Log.i(TAG, "xiaomi surfaces updated address=$address newDevice=$isNewDevice")
+            Log.d(TAG, "xiaomi surfaces updated address=$address newDevice=$isNewDevice")
         }.onFailure { Log.w(TAG, "xiaomi surface render failed", it) }
     }
 
@@ -434,7 +434,7 @@ object SonyEngineHost {
         val device = remoteDevice(context, address) ?: return
         runCatching {
             callMethod(service, "setBatteryLevel", device, level, false)
-            Log.i(TAG, "battery injected level=$level address=$address")
+            Log.d(TAG, "battery injected level=$level address=$address")
         }.onFailure { Log.w(TAG, "setBatteryLevel failed level=$level", it) }
     }
 }

--- a/app/src/main/java/dev/sonypods/hook/milink/MiLinkServiceHook.kt
+++ b/app/src/main/java/dev/sonypods/hook/milink/MiLinkServiceHook.kt
@@ -226,7 +226,7 @@ object MiLinkServiceHook : HookContext() {
             else -> 1
         }
         saveState(context)
-        Log.i(TAG, "state applied battery=${snapshot.batteryLeft}/${snapshot.batteryRight} anc=$currentAnc")
+        Log.d(TAG, "state applied battery=${snapshot.batteryLeft}/${snapshot.batteryRight} anc=$currentAnc")
         pushStateToPanel()
     }
 


### PR DESCRIPTION
将 4 处高频例行日志从 \Log.i\ 降为 \Log.d\，减少 LSPosed logcat 噪声：

- \MiLinkServiceHook\: \state applied battery=...\ — 每帧状态镜像都刷
- \SonyEngineHost\: \command=\, \surfaces updated\, \attery injected\ — 每次用户操作/状态更新都刷

这些日志在正常工作时没有调试价值。降为 \Log.d\ 后默认不显示，需要时仍可调级别查看。